### PR TITLE
Argus-ban: don't fail for authorization when listing PAPs

### DIFF
--- a/src/probes/argus-ban
+++ b/src/probes/argus-ban
@@ -121,7 +121,10 @@ def get_dyn_dn_dates(server, cert, key, salt, raw=False, all_raw=False):
                     transport = MyHTTPSTransport(key, cert),
                     plugins=[ListPoliciesFilter(salt, res, raw=raw, all_raw=all_raw)])
     for alias in aliases:
-        client.service.listPolicies(alias)
+        try:
+            client.service.listPolicies(alias)
+        except suds.WebFault, e:
+            pass
     return res
 
 


### PR DESCRIPTION
We only ask sites to give access to remote PAPs, no local PAPs, so listing
the content of local PAPs will fail, ignore them

Should fix GGUS:133259 (Can't test without the robot certificate :( )