### PR TITLE
Check Pakiti results before checking for mitigations

### DIFF
--- a/src/WN-probes/check_CVE-2018-1111
+++ b/src/WN-probes/check_CVE-2018-1111
@@ -5,6 +5,17 @@ NAGIOS_WARNING=1
 NAGIOS_ERROR=2
 NAGIOS_UNKNOWN=3
 
+PAKITI_RESULT="pakiti_results"
+
+if [ -s "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" pakiti_results 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "Pakiti didn't report any package vulnerable to $cve"
+        exit $NAGIOS_OK
+    fi
+fi
+
 if [ ! -f /etc/redhat-release ]; then
     echo "Only RedHat-based systems are affected"
     exit $NAGIOS_OK


### PR DESCRIPTION
The probe checks whether Pakiti results are available. If the report is found,
the probe will only carry on if the system was detected to expose the
vulnerability.