### PR TITLE
Check properly Pakiti results

### DIFF
--- a/src/WN-probes/check_CVE-2018-1111
+++ b/src/WN-probes/check_CVE-2018-1111
@@ -7,10 +7,10 @@ NAGIOS_UNKNOWN=3
 
 PAKITI_RESULT="pakiti_results"
 
-if [ -s "$PAKITI_RESULT" ]; then
+if [ -f "$PAKITI_RESULT" ]; then
     cve=$(echo $0 | sed 's/.*check_//')
-    grep -q "$cve" pakiti_results 2>/dev/null
-    if [ $? -eq 0 ]; then
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
         echo "Pakiti didn't report any package vulnerable to $cve"
         exit $NAGIOS_OK
     fi


### PR DESCRIPTION
If Pakiti doesn't find any tagged vulnerability it returns just an empty file.