### PR TITLE
Mitigation checks are skipped when the vulnerability isn't present.

### DIFF
--- a/src/WN-probes/check_CVE-2013-2094
+++ b/src/WN-probes/check_CVE-2013-2094
@@ -8,12 +8,24 @@ NAGIOS_WARNING=1
 NAGIOS_ERROR=2
 NAGIOS_UNKNOWN=3
 
+PAKITI_RESULT="pakiti_results"
+
 OK_KERNEL="2.6.32-358.6.2.el6"
 RUNNING_KERNEL=$(uname -r | sed -e "s/.$(uname -m)//")
 
 verlte() {
     [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
 }
+
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
 
 # check for affected distribution
 if [[ $RUNNING_KERNEL =~ ".el5" ]]; then

--- a/src/WN-probes/check_CVE-2016-5195
+++ b/src/WN-probes/check_CVE-2016-5195
@@ -3,6 +3,17 @@
 NAGIOS_OK=0
 NAGIOS_ERROR=2
 
+PAKITI_RESULT="pakiti_results"
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
+
 lsmod | grep -q cve_2016_5195
 if [ $? -eq 0 ]; then
 	echo "CERN module detected (supposedly with systemtap mitigations)"

--- a/src/WN-probes/check_CVE-2018-1111
+++ b/src/WN-probes/check_CVE-2018-1111
@@ -11,7 +11,7 @@ if [ -f "$PAKITI_RESULT" ]; then
     cve=$(echo $0 | sed 's/.*check_//')
     grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
     if [ $? -eq 1 ]; then
-        echo "Pakiti didn't report any package vulnerable to $cve"
+        echo "No $cve vulnerability found, skipping the mitigation check"
         exit $NAGIOS_OK
     fi
 fi

--- a/src/WN-probes/check_CVE-2018-12021
+++ b/src/WN-probes/check_CVE-2018-12021
@@ -3,7 +3,18 @@
 NAGIOS_OK=0
 NAGIOS_ERROR=2
 
+PAKITI_RESULT="pakiti_results"
+
 SINGULARITY_CONFIG=/etc/singularity/singularity.conf
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
 
 if [ -d /usr/libexec/singularity ]; then
     SUID_SET="no"

--- a/src/WN-probes/check_CVE-2018-14634
+++ b/src/WN-probes/check_CVE-2018-14634
@@ -3,6 +3,17 @@
 NAGIOS_OK=0
 NAGIOS_ERROR=2
 
+PAKITI_RESULT="pakiti_results"
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
+
 mem_total=$(free -g | grep 'Mem:' | awk '{print $2}')
 if [ $mem_total -lt 32 ]; then
     echo "Systems with less than 32GB of memory should be safe"

--- a/src/WN-probes/check_CVE-2021-3156
+++ b/src/WN-probes/check_CVE-2021-3156
@@ -5,6 +5,17 @@ NAGIOS_WARNING=1
 NAGIOS_ERROR=2
 NAGIOS_UNKNOWN=3
 
+PAKITI_RESULT="pakiti_results"
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
+
 sudo=$(which sudo)
 
 if [ -z "$sudo" ]; then

--- a/src/WN-probes/check_EGI-SVG-2016-5195
+++ b/src/WN-probes/check_EGI-SVG-2016-5195
@@ -3,6 +3,17 @@
 NAGIOS_OK=0
 NAGIOS_ERROR=2
 
+PAKITI_RESULT="pakiti_results"
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
+
 lsmod | grep -q cve_2016_5195
 if [ $? -eq 0 ]; then
 	echo "CERN module detected (supposedly with systemtap mitigations)"

--- a/src/WN-probes/check_EGI-SVG-2018-14213
+++ b/src/WN-probes/check_EGI-SVG-2018-14213
@@ -3,7 +3,18 @@
 NAGIOS_OK=0
 NAGIOS_ERROR=2
 
+PAKITI_RESULT="pakiti_results"
+
 SINGULARITY_CONFIG=/etc/singularity/singularity.conf
+
+if [ -f "$PAKITI_RESULT" ]; then
+    cve=$(echo $0 | sed 's/.*check_//')
+    grep -q "$cve" "$PAKITI_RESULT" 2>/dev/null
+    if [ $? -eq 1 ]; then
+        echo "No $cve vulnerability found, skipping the mitigation check"
+        exit $NAGIOS_OK
+    fi
+fi
 
 SUID_SET="no"
 for bin in /usr/libexec/singularity/bin/*-suid; do


### PR DESCRIPTION
The mitigation probes check the results produced by the Pakiti probe and are
only performed if Pakiti detects the vulnerability.