### PR TITLE
Setup a basic $PATH environment variable before executing probes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* Tue Mar 9 2021 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.2-0
+- Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
+
 * Mon Mar 8 2021 Daniel Kouril <kouril@ics.muni.cz> - 2.1.1-0
 - check_CVE-2018-12021: Check singularity is available before it's checked.
 - CRL: Don't check CRLs if there's no certificate on the system.

--- a/grid-monitoring-probes-eu.egi.sec.spec
+++ b/grid-monitoring-probes-eu.egi.sec.spec
@@ -5,7 +5,7 @@
 
 Summary: Security monitoring probes based on EGI CSIRT requirements
 Name: grid-monitoring-probes-eu.egi.sec
-Version: 2.1.1
+Version: 2.1.2
 Release: 0%{?dist}
 
 License: ASL 2.0
@@ -121,6 +121,9 @@ cd -
 /usr/libexec/grid-monitoring/wnfm
 
 %changelog
+* Tue Mar 9 2021 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.2-0
+- Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
+
 * Mon Mar 8 2021 Daniel Kouril <kouril@ics.muni.cz> - 2.1.1-0
 - check_CVE-2018-12021: Check singularity is available before it's checked.
 - CRL: Don't check CRLs if there's no certificate on the system.

--- a/src/CREAM/testjob.sh
+++ b/src/CREAM/testjob.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# setup a basic PATH just in case
+export PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
+
 tar -zxf WN-probes.tar.gz
 
 for probe in `cat probe_list`; do

--- a/src/HTCondor/etf_run.sh
+++ b/src/HTCondor/etf_run.sh
@@ -5,6 +5,9 @@
 # Kyriakos Gkinis <kyrginis at admin grnet gr>
 #
 
+# setup a basic PATH just in case
+export PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
+
 # decompress HTCondor probe payload
 tar zxf gridjob.tgz
 


### PR DESCRIPTION
Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.

Updated CHANGES and SPEC files. Bumped version to 2.1.2.