### PR TITLE
Pakiti check in check_CVE-2015-3245. $PATH, $SITE_NAME and backslash escaping in etf_run.sh.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* Tue Mar 9 2021 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.2-0
+- Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
+
 * Mon Mar 8 2021 Daniel Kouril <kouril@ics.muni.cz> - 2.1.1-0
 - check_CVE-2018-12021: Check singularity is available before it's checked.
 - CRL: Don't check CRLs if there's no certificate on the system.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+* Tue Mar 9 2021 Daniel Kouril <kouril@ics.muni.cz> and Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.3-0
+- check_CVE-2015-3245: Mitigation checks are skipped when the vulnerability isn't present.
+- HTCondor-CE etf_run.sh script:
+  * Set $SITE_NAME environment variable.
+  * Escape backslashes in the output of WN probes.
+
 * Tue Mar 9 2021 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.2-0
 - Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
 

--- a/grid-monitoring-probes-eu.egi.sec.spec
+++ b/grid-monitoring-probes-eu.egi.sec.spec
@@ -5,7 +5,7 @@
 
 Summary: Security monitoring probes based on EGI CSIRT requirements
 Name: grid-monitoring-probes-eu.egi.sec
-Version: 2.1.2
+Version: 2.1.3
 Release: 0%{?dist}
 
 License: ASL 2.0
@@ -121,6 +121,12 @@ cd -
 /usr/libexec/grid-monitoring/wnfm
 
 %changelog
+* Tue Mar 9 2021 Daniel Kouril <kouril@ics.muni.cz> and Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.3-0
+- check_CVE-2015-3245: Mitigation checks are skipped when the vulnerability isn't present.
+- HTCondor-CE etf_run.sh script:
+  * Set $SITE_NAME environment variable.
+  * Escape backslashes in the output of WN probes.
+
 * Tue Mar 9 2021 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.2-0
 - Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
 

--- a/grid-monitoring-probes-eu.egi.sec.spec
+++ b/grid-monitoring-probes-eu.egi.sec.spec
@@ -5,7 +5,7 @@
 
 Summary: Security monitoring probes based on EGI CSIRT requirements
 Name: grid-monitoring-probes-eu.egi.sec
-Version: 2.1.1
+Version: 2.1.2
 Release: 0%{?dist}
 
 License: ASL 2.0
@@ -121,6 +121,9 @@ cd -
 /usr/libexec/grid-monitoring/wnfm
 
 %changelog
+* Tue Mar 9 2021 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.2-0
+- Setup a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
+
 * Mon Mar 8 2021 Daniel Kouril <kouril@ics.muni.cz> - 2.1.1-0
 - check_CVE-2018-12021: Check singularity is available before it's checked.
 - CRL: Don't check CRLs if there's no certificate on the system.

--- a/src/CREAM/testjob.sh
+++ b/src/CREAM/testjob.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# setup a basic PATH just in case
+export PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
+
 tar -zxf WN-probes.tar.gz
 
 for probe in `cat probe_list`; do

--- a/src/HTCondor/etf_run.sh
+++ b/src/HTCondor/etf_run.sh
@@ -5,6 +5,9 @@
 # Kyriakos Gkinis <kyrginis at admin grnet gr>
 #
 
+# setup a basic PATH just in case
+export PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
+
 # decompress HTCondor probe payload
 tar zxf gridjob.tgz
 

--- a/src/HTCondor/etf_run.sh
+++ b/src/HTCondor/etf_run.sh
@@ -17,6 +17,9 @@ source ./etf-env.sh
 # get Worker Node hostname
 gatheredAt=`hostname -f`
 
+# SITE_NAME for Pakiti
+export SITE_NAME=$eu_egi_sec_sitename
+
 # CE hostname
 service_uri=$eu_egi_sec_service_uri
 
@@ -39,6 +42,10 @@ for probe in `cat probe_list`; do
        ;;
    esac
 
+   # escape backslashes - we need 6 in the json - 12 here
+   sed -i 's/\\/\\\\\\\\\\\\/g' ${probe}.out
+
+   # escape doublequotes
    sed -i 's/"/\\"/g' ${probe}.out
 
    summary=$(head -1 ${probe}.out)


### PR DESCRIPTION
Added forgotten Pakiti check to check_CVE-2015-3245.
In HTCondor/etf_run.sh, set $SITE_NAME and escaped backslashes in the output of WN probes.
Set a basic $PATH environment variable before executing probes on CREAM and HTCondor-CE.
Updated CHANGES and SPEC files.
Bumped version to 2.1.3.