### PR TITLE
Add new instance of pakiti server

### DIFF
--- a/src/WN-probes/pakiti-client
+++ b/src/WN-probes/pakiti-client
@@ -2,7 +2,7 @@
 
 # Default values
 CONF=''
-SERVERS="pakiti2.egi.eu:443 pakiti3.egi.eu:443"
+SERVERS="pakiti2.egi.eu:443 pakiti3.egi.eu:443 pakiti.metacentrum.cz:443"
 SERVER_URL="/feed/"
 METHOD="autodetect"
 OPENSSL_BIN=`which openssl 2>/dev/null`


### PR DESCRIPTION
We are deploying and trying to test new instance of pakiti server for EGI. So I added to pakiti-client DN of new server. We want to test it simultaneously with pakiti.egi.eu and if everything works fine, then we will shut down the old instance.

Thank you,

Jakub Havrila
MetaCentrum(CESNET)