### PR TITLE
added new production pakiti-server

### DIFF
--- a/src/WN-probes/pakiti-client
+++ b/src/WN-probes/pakiti-client
@@ -2,7 +2,7 @@
 
 # Default values
 CONF=''
-SERVERS="pakiti2.egi.eu:443 pakiti3.egi.eu:443 pakiti.metacentrum.cz:443"
+SERVERS="pakiti2.egi.eu:443 pakiti3.egi.eu:443 pakiti.egi.eu:443"
 SERVER_URL="/feed/"
 METHOD="autodetect"
 OPENSSL_BIN=`which openssl 2>/dev/null`


### PR DESCRIPTION
We decided to change receiving server to pakiti.egi.eu as new production pakiti server. This change relates to PR #64. 

Thank you,
Jakub Havrila
MetaCentrum(CESNET)