### PR TITLE
Fixed execution of Python script check_CVE-2026-31431 in the ARC configuration. Version 2.1.29-1.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* Mon May 18 2026 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.29-1
+- Fixed execution of Python script check_CVE-2026-31431 in the ARC configuration.
+
 * Thu May 14 2026 Jakub Havrila <havrila@cesnet.cz> - 2.1.29-0
 - Added mitigation checks for CVE-2026-43284 and CVE-2026-46300.
 

--- a/grid-monitoring-probes-eu.egi.sec.spec
+++ b/grid-monitoring-probes-eu.egi.sec.spec
@@ -6,7 +6,7 @@
 Summary: Security monitoring probes based on EGI CSIRT requirements
 Name: grid-monitoring-probes-eu.egi.sec
 Version: 2.1.29
-Release: 0%{?dist}
+Release: 1%{?dist}
 
 License: ASL 2.0
 Group: Applications/System
@@ -139,6 +139,9 @@ cd -
 /usr/libexec/grid-monitoring/wnfm
 
 %changelog
+* Mon May 18 2026 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 2.1.29-1
+- Fixed execution of Python script check_CVE-2026-31431 in the ARC configuration.
+
 * Thu May 14 2026 Jakub Havrila <havrila@cesnet.cz> - 2.1.29-0
 - Added mitigation checks for CVE-2026-43284 and CVE-2026-46300.
 

--- a/src/ARC/50-secmon.ini
+++ b/src/ARC/50-secmon.ini
@@ -262,7 +262,7 @@ jobplugin = scripted
 staged_inputs = file:%(config_dir)s/50-secmon.d/check_CVE-2026-31431
 output_file = check_CVE-2026-31431.out
 service_description = eu.egi.sec.WN-check_CVE-2026-31431%(service_suffix)s
-script_line = (env PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH /bin/bash check_CVE-2026-31431 2>&1; retv=$? ; [ $retv -gt 3 ] && retv=3 ; echo __status $retv $(hostname):) | \
+script_line = (env PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH python3 check_CVE-2026-31431 2>&1; retv=$? ; [ $retv -gt 3 ] && retv=3 ; echo __status $retv $(hostname):) | \
     (read msg; sed -e 's/^/__log 20 /' -e '$s;^__log 20 \(.*\);\1 '"$msg;") \
     > check_CVE-2026-31431.out
 


### PR DESCRIPTION
Fixed execution of Python script check_CVE-2026-31431 in the ARC configuration.
Bumped version to 2.1.29-1.